### PR TITLE
CB-58: Improve the search history display

### DIFF
--- a/app/js/components/page/pageComponent.jsx
+++ b/app/js/components/page/pageComponent.jsx
@@ -14,7 +14,7 @@ class PageComponent extends Component{
     }
 
     componentDidMount() {
-        const currentHistory = JSON.parse(window.sessionStorage.getItem('openmrsHistory'));
+        const currentHistory = JSON.parse(window.sessionStorage.getItem('openmrsHistory')).reverse();
         if(currentHistory) {
             this.setState({history: currentHistory});
         }
@@ -23,7 +23,7 @@ class PageComponent extends Component{
     addToHistory(description, total, parameters) {
         const newHistory = [...this.state.history, {description, total, parameters}];
         window.sessionStorage.setItem('openmrsHistory', JSON.stringify(newHistory));
-        this.setState({history: newHistory});
+        this.setState({history: newHistory.reverse()});
     }
 
     render(){

--- a/app/js/components/searchHistory/searchHistory.css
+++ b/app/js/components/searchHistory/searchHistory.css
@@ -15,28 +15,22 @@
     background-color: #ccc;
     color: #000;
     padding: 10px;
-    border-color: #000;
-    border-width: 1px;
-    border-style: solid;
     margin-top: 20px;
     margin-bottom: 20px;
 }
 
 .result-window {
     padding: 10px;
-    border-color: #000;
-    border-width: 1px;
-    border-style: solid;
     margin-top: 20px;
     margin-bottom: 20px;
+    max-height: 300px;
+    overflow-y: auto;
 }
 
-.view-result, .save {
-    cursor: pointer;
-}
-.save {
+.save, .view {
     color: #000;
-    font-size: 20px;
+    cursor: pointer;
+    font-size: 15px;
 }
 
 .view-result {

--- a/app/js/components/searchHistory/searchHistoryComponent.jsx
+++ b/app/js/components/searchHistory/searchHistoryComponent.jsx
@@ -23,7 +23,7 @@ class SearchHistoryComponent extends Component {
     componentWillReceiveProps(nextProps) {
         this.setState({searchHistory: nextProps.history});
         if(nextProps.history.length > 0) {
-             this.viewResult(nextProps.history[nextProps.history.length -1].parameters);
+             this.viewResult(nextProps.history[0].parameters);
         }
     }
 
@@ -91,10 +91,11 @@ class SearchHistoryComponent extends Component {
                                     {
                                         this.state.searchHistory.map((eachResult, index) =>
                                             <tr key={shortId.generate()}>
+                                                <td>{index + 1}</td>
                                                 <td>{eachResult.description}</td>
                                                 <td>{eachResult.total +' result(s)'}</td>
-                                                <td><span className="glyphicon glyphicon-glyphicon glyphicon-floppy-disk save" aria-hidden="true"></span></td>
-                                                <td onClick={() => this.viewResult(index)} className="view-result">View</td>
+                                                <td><span className="glyphicon glyphicon-floppy-disk save" aria-hidden="true" title="Save" /></td>
+                                                <td><span className="glyphicon glyphicon-eye-open view" title="View" aria-hidden="true" onClick={() => this.viewResult(index)} /></td>
                                             </tr>
                                         )
                                     }


### PR DESCRIPTION
# JIRA TICKET NAME:
CB-58: [Improve the search history display](https://issues.openmrs.org/browse/CB-58)
## SUMMARY:
Improve the UI & UX of the display of search history
1.) Newer searches should be at the top
2.) The search history should have a fixed height and a scrollbar once the number of searches exceeds the specified height
3.) Remove the black border surrounding the search history
4.) use icon to represent view and there should be tool tip that displays save & view when you hover on the icons
5.) The table border should not have a line at the top
